### PR TITLE
redirection bug fixed

### DIFF
--- a/frontend/src/components/LeafletMap.js
+++ b/frontend/src/components/LeafletMap.js
@@ -10,11 +10,16 @@ function LeafletMap() {
     if (mapRef.current) {
       const map = L.map(mapRef.current).setView([51.505, -0.09], 12); // Set the initial center and zoom level
 
-      // Add the Bing Aerial Layer
-      L.tileLayer.bing({
-        bingMapsKey: localStorage.getItem('bing_api'), // Replace with your Bing Maps API Key
-        imagerySet: 'Aerial',
-      }).addTo(map);
+      if (localStorage.getItem('bing_api')) {
+        // User is authenticated, so initialize the Bing Maps layer
+        L.tileLayer.bing({
+          bingMapsKey: localStorage.getItem('bing_api'),
+          imagerySet: 'Aerial',
+        }).addTo(map);
+      } else {
+        // User is not authenticated, initialize a different map layer (e.g., OpenStreetMap)
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+      }
 
       return () => {
         map.remove(); // Remove the map when the component unmounts


### PR DESCRIPTION
Fixed the bug that would break the code when trying to access the dashboard as a non-authenticated user after adding in the dashboard a leaflet map requiring a bing API key to render. 

- Modified LeafletMap.js to initialise an empty map
- If a Bing API key is present, which is not the case when the user is authenticated, then a newly implemented conditional rendering allows to initialise an OS map, which does nor require authentication. This won't be rendered as there will be redirection, but is required because of the way React runs the component code before rendering. 

This new fix allows to still visualise a map for an authenticated user even in case the Bing API for whatever reason is not available 

